### PR TITLE
Фикс некорректного поведения

### DIFF
--- a/modhelper_full.appr.user.js
+++ b/modhelper_full.appr.user.js
@@ -15,7 +15,6 @@
 // @match         http://nnm-club.ru/forum/modcp.php*
 // @match         https://*.nnm-club.ru/forum/modcp.php*
 // @match         https://nnm-club.ru/forum/modcp.php*
-// @run-at        document-start
 // ==/UserScript==
 // 
 


### PR DESCRIPTION
Директива // @run-at  document-start позволяет запустить скрипт до окончания формирования всех элементов страницы (по событию DOMContentloaded), но в данном скрипте в некоторых случаях данное поведение не дает правильно отрабатывать работу с HTML т.к. они еще не отрисованы, а скрипт пытается выполнить действие.
